### PR TITLE
Expand tests and include app.py in CI lint/format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
           python -m pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Format check (Black)
-        run: black --check tests
+        run: black --check app.py tests
 
       - name: Lint (Pylint)
-        run: pylint tests
+        run: pylint app.py tests
 
       - name: Static analysis (mypy)
         run: mypy tests

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(PROJECT_ROOT))
 
@@ -52,6 +54,42 @@ def test_get_commands_for_host_uses_model(tmp_path: Path, monkeypatch) -> None:
     assert commands == app.DEVICE_COMMANDS["cisco"]
 
 
+def test_get_device_info_missing_host_returns_none(tmp_path: Path, monkeypatch) -> None:
+    """Return None when a host entry is not found in the CSV."""
+    hosts_csv = tmp_path / "hosts.csv"
+    hosts_csv.write_text(
+        """host,ip,username,port,model\nrouter1,10.0.0.1,admin,22,cisco\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(app, "HOSTS_CSV", str(hosts_csv))
+
+    device_info = app.get_device_info("router2")
+
+    assert device_info is None
+
+
+def test_get_commands_for_host_returns_default_for_unknown_model(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Return default commands when the model is unknown."""
+    hosts_csv = tmp_path / "hosts.csv"
+    hosts_csv.write_text(
+        """host,ip,username,port,model\nrouter1,10.0.0.1,admin,22,unknown\n""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(app, "HOSTS_CSV", str(hosts_csv))
+
+    commands = app.get_commands_for_host("router1")
+
+    assert commands == app.DEFAULT_COMMANDS
+
+
+def test_get_file_path_invalid_base_raises() -> None:
+    """Raise a ValueError when the base directory is invalid."""
+    with pytest.raises(ValueError, match="Invalid base"):
+        app.get_file_path("router1", "show version", "archive")
+
+
 def test_compute_diff_status_identical() -> None:
     """Return identical status when content matches."""
     assert app.compute_diff_status("same", "same") == "identical"
@@ -70,3 +108,12 @@ def test_compute_diff_inline_contains_diff_markup() -> None:
 
     assert status == "changes detected"
     assert "<del" in diff_html or "<ins" in diff_html
+
+
+def test_generate_side_by_side_html_includes_highlights() -> None:
+    """Side-by-side HTML should include diff and line highlights."""
+    html = app.generate_side_by_side_html("hello\nworld\n", "hello\nthere\n")
+
+    assert "<del" in html
+    assert "<ins" in html
+    assert "background-color: #ffff99" in html


### PR DESCRIPTION
### Motivation
- Add additional unit coverage around host lookup defaults and side-by-side diff rendering to improve test reliability.
- Ensure the main application module `app.py` is checked by formatters and linters in CI to catch style and lint regressions early.
- Add license and LLM-attribution headers to modified source per project requirements.

### Description
- Add new unit tests in `tests/test_app.py` covering `get_device_info` missing-host behavior, fallback to `DEFAULT_COMMANDS`, invalid base handling for `get_file_path`, and side-by-side HTML highlights.
- Add Apache-2.0 license + LLM attribution header to `app.py`, and adjust exception variable names with `pylint` suppression comments to satisfy lint feedback.
- Update CI workflow `.github/workflows/ci.yml` to run `black` and `pylint` against both `app.py` and `tests`, and keep `mypy` and `pytest` steps.
- Run `black` to format changed files and apply minor formatting updates in `app.py` and `tests/test_app.py`.
- Files modified by LLM assistance: `app.py`, `tests/test_app.py`, `.github/workflows/ci.yml`; human review: not yet performed.

### Testing
- Ran formatting and applied changes with `python -m black app.py tests`, which reformatted the files and completed successfully.
- Verified formatting check with `python -m black --check app.py tests`, which reports files are correctly formatted (no changes needed after reformat).
- Ran static type checks with `python -m mypy tests`, which completed with `Success: no issues found in 1 source file`.
- Executed the test suite with `python -m pytest`, which passed all tests (`9 passed`).
- Attempted `python -m pylint app.py tests`, which could not run because `pylint` was not available in the environment (installation failed due to network/proxy restrictions).
- Attempted `pre-commit run --all-files`, which could not run because `pre-commit` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676798430883309ac2ec580b70c0f6)