### PR TITLE
fix(ci): resolve pip audit vulnerabilities

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ mypy==1.19.1
 pip-audit==2.10.0
 pre-commit==4.5.1
 pylint==4.0.5
-pytest==9.0.2
+pytest==9.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,9 @@ MarkupSafe==3.0.3
 mdurl==0.1.2
 netmiko==4.6.0
 ntc_templates==9.0.0
-paramiko==4.0.0
+paramiko==5.0.0
 pycparser==3.0
-Pygments==2.19.2
+Pygments==2.20.0
 PyNaCl==1.6.2
 pyserial==3.5
 PyYAML==6.0.3


### PR DESCRIPTION
## Summary
- bump paramiko to 5.0.0 to clear CVE-2026-44405
- bump pytest to 9.0.3 to clear CVE-2025-71176
- bump Pygments to 2.20.0 to clear CVE-2026-4539

## Verification
- `pip-audit -r requirements.txt -r requirements-dev.txt`
- `black --check src tests`
- `mypy src tests`
- `pylint src tests`
- `pytest`