### PR TITLE
[codex] Enable GitHub Pages during deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Upload docs
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Set `enablement: true` on `actions/configure-pages@v5`.

## Rationale
The first GitHub Pages deployment failed because the repository did not yet have a Pages site configured. The configure step logged `enablement: false` and failed with `Get Pages site failed`. Enabling this option lets the workflow create/configure the Pages site for GitHub Actions deployment.

## Validation
- Inspected the failed Pages workflow log for run `27178353376`.
- Verified the workflow YAML diff is limited to the configure-pages input.

## LLM involvement
Files modified with LLM assistance:
- `.github/workflows/pages.yml`

Human review required for correctness, security, licensing, and final publishing behavior.