### PR TITLE
[codex] Improve UX tour presentation

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -81,6 +81,7 @@ export NW_DIFF_ENV=development
 - 言語運用方針:
   - 原則として各ドキュメントは 1 ファイル内で英語 + 日本語訳を併記します。
   - トップガイドは `README.md`（英語中心）と `README_ja.md`（日本語中心）に分けて管理します。
+- [ユーザーエクスペリエンスツアー](https://icecake0141.github.io/nw-diff/tour/?lang=ja) - スクリーンショット付きの日本語/英語切替ウォークスルー
 - [トップ README（英語）](README.md)
 - [仕様（SPEC）](docs/SPEC.md)
 - [テスト手順](docs/TESTING.md)

--- a/docs/tour/index.html
+++ b/docs/tour/index.html
@@ -21,6 +21,15 @@ Review required for correctness, security, and licensing.
       name="description"
       content="A bilingual product tour for NW-Diff, showing capture, comparison, and operational diagnostics through the v2 web UI."
     />
+    <meta property="og:title" content="NW-Diff User Experience Tour" />
+    <meta
+      property="og:description"
+      content="Capture before and after network states, compare command output, and keep operational evidence in one workflow."
+    />
+    <meta property="og:image" content="https://icecake0141.github.io/nw-diff/assets/tour/control-panel.jpg" />
+    <meta property="og:url" content="https://icecake0141.github.io/nw-diff/tour/" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
     <link rel="stylesheet" href="./tour.css" />
   </head>
   <body>
@@ -49,6 +58,20 @@ Review required for correctness, security, and licensing.
           <div class="hero-actions">
             <a class="primary-action" href="#screenshots" data-i18n="heroPrimary">Explore the UI</a>
             <a class="secondary-action" href="https://github.com/icecake0141/nw-diff#installation" data-i18n="heroSecondary">Read setup guide</a>
+          </div>
+          <div class="value-strip" aria-label="NW-Diff value summary">
+            <article>
+              <strong data-i18n="valueOneTitle">Before/after capture</strong>
+              <span data-i18n="valueOneText">Collect origin and destination snapshots across the inventory.</span>
+            </article>
+            <article>
+              <strong data-i18n="valueTwoTitle">Command-level diff</strong>
+              <span data-i18n="valueTwoText">Review device output by command with timestamps and status.</span>
+            </article>
+            <article>
+              <strong data-i18n="valueThreeTitle">Operational evidence</strong>
+              <span data-i18n="valueThreeText">Keep task history and logs close to the change review.</span>
+            </article>
           </div>
         </div>
         <figure class="hero-shot">
@@ -99,8 +122,17 @@ Review required for correctness, security, and licensing.
               Operators can start origin or destination captures, monitor the current task, filter hosts, and confirm
               per-command coverage without opening separate tooling.
             </p>
+            <ul class="callout-list">
+              <li data-i18n="controlCalloutOne">Batch actions are one click away during a change window.</li>
+              <li data-i18n="controlCalloutTwo">Host rows expose command coverage before opening detail.</li>
+            </ul>
           </div>
-          <img src="../assets/tour/control-panel.jpg" alt="Control panel with capture buttons, progress status, and host table" />
+          <div class="annotated-shot">
+            <img src="../assets/tour/control-panel.jpg" alt="Control panel with capture buttons, progress status, and host table" />
+            <span class="annotation control-a" data-i18n="annotateBatch">Batch capture</span>
+            <span class="annotation control-b" data-i18n="annotateProgress">Task progress</span>
+            <span class="annotation control-c" data-i18n="annotateCoverage">Per-command coverage</span>
+          </div>
         </article>
 
         <article class="shot-block reverse">
@@ -110,8 +142,17 @@ Review required for correctness, security, and licensing.
               The host view brings inventory metadata, capture actions, comparison summaries, and command output into
               a single evidence trail for one network device.
             </p>
+            <ul class="callout-list">
+              <li data-i18n="detailCalloutOne">Inventory metadata remains visible while reviewing output.</li>
+              <li data-i18n="detailCalloutTwo">Changed and identical commands can be scanned in one pass.</li>
+            </ul>
           </div>
-          <img src="../assets/tour/host-detail.jpg" alt="Host detail screen showing device metadata and command comparison results" />
+          <div class="annotated-shot">
+            <img src="../assets/tour/host-detail.jpg" alt="Host detail screen showing device metadata and command comparison results" />
+            <span class="annotation detail-a" data-i18n="annotateMetadata">Device metadata</span>
+            <span class="annotation detail-b" data-i18n="annotateCompare">Compare controls</span>
+            <span class="annotation detail-c" data-i18n="annotateResults">Command results</span>
+          </div>
         </article>
 
         <article class="shot-block">
@@ -121,8 +162,16 @@ Review required for correctness, security, and licensing.
               Runtime logs are close to the workflow, so failed captures and deployment checks can be investigated
               with context instead of switching to a terminal first.
             </p>
+            <ul class="callout-list">
+              <li data-i18n="logsCalloutOne">Filters keep noisy runtime output manageable.</li>
+              <li data-i18n="logsCalloutTwo">Log entries support handoff after failed captures.</li>
+            </ul>
           </div>
-          <img src="../assets/tour/logs.jpg" alt="NW-Diff logs page showing recent runtime entries" />
+          <div class="annotated-shot">
+            <img src="../assets/tour/logs.jpg" alt="NW-Diff logs page showing recent runtime entries" />
+            <span class="annotation logs-a" data-i18n="annotateFilters">Source filters</span>
+            <span class="annotation logs-b" data-i18n="annotateRuntime">Runtime trail</span>
+          </div>
         </article>
       </section>
 

--- a/docs/tour/tour.css
+++ b/docs/tour/tour.css
@@ -23,6 +23,7 @@
   --accent: #0f766e;
   --accent-dark: #0b5d57;
   --gold: #b7791f;
+  --blue: #1d4ed8;
   --shadow: 0 18px 45px rgba(23, 32, 42, 0.12);
 }
 
@@ -143,6 +144,37 @@ main {
   font-size: 18px;
 }
 
+.value-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.value-strip article {
+  border: 1px solid rgba(15, 118, 110, 0.22);
+  border-radius: 8px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.value-strip strong,
+.value-strip span {
+  display: block;
+}
+
+.value-strip strong {
+  margin-bottom: 6px;
+  color: var(--ink);
+  font-size: 14px;
+}
+
+.value-strip span {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -178,7 +210,7 @@ main {
 }
 
 .hero-shot img,
-.shot-block img {
+.annotated-shot img {
   display: block;
   width: 100%;
   border: 1px solid var(--line);
@@ -286,6 +318,129 @@ figcaption {
   font-size: 16px;
 }
 
+.callout-list {
+  display: grid;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.callout-list li {
+  border-left: 3px solid var(--accent);
+  padding-left: 10px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.annotated-shot {
+  position: relative;
+}
+
+.annotation {
+  position: absolute;
+  max-width: 180px;
+  border: 1px solid rgba(29, 78, 216, 0.28);
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--blue);
+  box-shadow: 0 12px 24px rgba(23, 32, 42, 0.15);
+  font-size: 12px;
+  font-weight: 800;
+  line-height: 1.25;
+}
+
+.annotation::after {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--blue);
+  box-shadow: 0 0 0 5px rgba(29, 78, 216, 0.18);
+  content: "";
+}
+
+.control-a {
+  top: 4.4%;
+  left: 4.5%;
+}
+
+.control-a::after {
+  top: 36px;
+  left: 12px;
+}
+
+.control-b {
+  top: 12%;
+  right: 18%;
+}
+
+.control-b::after {
+  top: 38px;
+  right: 16px;
+}
+
+.control-c {
+  top: 31%;
+  left: 45%;
+}
+
+.control-c::after {
+  top: 37px;
+  left: 20px;
+}
+
+.detail-a {
+  top: 7%;
+  right: 10%;
+}
+
+.detail-a::after {
+  top: 38px;
+  right: 14px;
+}
+
+.detail-b {
+  top: 24%;
+  left: 6%;
+}
+
+.detail-b::after {
+  top: 38px;
+  left: 20px;
+}
+
+.detail-c {
+  top: 41%;
+  left: 44%;
+}
+
+.detail-c::after {
+  top: 38px;
+  left: 18px;
+}
+
+.logs-a {
+  top: 17%;
+  left: 8%;
+}
+
+.logs-a::after {
+  top: 38px;
+  left: 18px;
+}
+
+.logs-b {
+  top: 42%;
+  left: 42%;
+}
+
+.logs-b::after {
+  top: 38px;
+  left: 18px;
+}
+
 .operate {
   background: var(--surface-soft);
 }
@@ -348,6 +503,10 @@ code {
   .steps {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .value-strip {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 620px) {
@@ -365,5 +524,15 @@ code {
 
   .footer {
     flex-direction: column;
+  }
+
+  .annotation {
+    position: static;
+    display: inline-block;
+    margin: 8px 6px 0 0;
+  }
+
+  .annotation::after {
+    display: none;
   }
 }

--- a/docs/tour/tour.js
+++ b/docs/tour/tour.js
@@ -24,6 +24,12 @@ const translations = {
     heroPrimary: "Explore the UI",
     heroSecondary: "Read setup guide",
     heroCaption: "The v2 control panel keeps batch actions, progress, and host coverage visible.",
+    valueOneTitle: "Before/after capture",
+    valueOneText: "Collect origin and destination snapshots across the inventory.",
+    valueTwoTitle: "Command-level diff",
+    valueTwoText: "Review device output by command with timestamps and status.",
+    valueThreeTitle: "Operational evidence",
+    valueThreeText: "Keep task history and logs close to the change review.",
     workflowEyebrow: "Guided operating flow",
     workflowTitle: "A tour built around the way network teams review changes.",
     stepOneTitle: "Load the device inventory",
@@ -41,12 +47,26 @@ const translations = {
     controlTitle: "Control panel for live coverage",
     controlText:
       "Operators can start origin or destination captures, monitor the current task, filter hosts, and confirm per-command coverage without opening separate tooling.",
+    controlCalloutOne: "Batch actions are one click away during a change window.",
+    controlCalloutTwo: "Host rows expose command coverage before opening detail.",
+    annotateBatch: "Batch capture",
+    annotateProgress: "Task progress",
+    annotateCoverage: "Per-command coverage",
     detailTitle: "Host detail for command-level review",
     detailText:
       "The host view brings inventory metadata, capture actions, comparison summaries, and command output into a single evidence trail for one network device.",
+    detailCalloutOne: "Inventory metadata remains visible while reviewing output.",
+    detailCalloutTwo: "Changed and identical commands can be scanned in one pass.",
+    annotateMetadata: "Device metadata",
+    annotateCompare: "Compare controls",
+    annotateResults: "Command results",
     logsTitle: "Logs for investigation and handoff",
     logsText:
       "Runtime logs are close to the workflow, so failed captures and deployment checks can be investigated with context instead of switching to a terminal first.",
+    logsCalloutOne: "Filters keep noisy runtime output manageable.",
+    logsCalloutTwo: "Log entries support handoff after failed captures.",
+    annotateFilters: "Source filters",
+    annotateRuntime: "Runtime trail",
     operateEyebrow: "Run it locally",
     operateTitle: "Start the v2 UI and follow the same tour with your devices.",
     operateText: "Open http://127.0.0.1:5000/v2 after startup.",
@@ -63,6 +83,12 @@ const translations = {
     heroPrimary: "UIを見る",
     heroSecondary: "セットアップを読む",
     heroCaption: "v2コントロールパネルでは、一括操作、進捗、ホスト別の取得状況を同じ画面で確認できます。",
+    valueOneTitle: "変更前後の取得",
+    valueOneText: "インベントリ全体からOriginとDestinationのスナップショットを取得します。",
+    valueTwoTitle: "コマンド単位の差分",
+    valueTwoText: "タイムスタンプと状態を含めて、機器出力をコマンド単位で確認します。",
+    valueThreeTitle: "運用証跡",
+    valueThreeText: "タスク履歴とログを変更確認の近くに置きます。",
     workflowEyebrow: "運用フロー",
     workflowTitle: "ネットワークチームの変更確認に合わせたユーザーエクスペリエンスツアー。",
     stepOneTitle: "機器インベントリを読み込む",
@@ -78,12 +104,26 @@ const translations = {
     controlTitle: "取得状況を見渡すコントロールパネル",
     controlText:
       "運用者はOrigin/Destination取得、現在のタスク監視、ホスト絞り込み、コマンド単位の取得状況確認を別ツールなしで行えます。",
+    controlCalloutOne: "変更ウィンドウ中でも一括取得をすぐ開始できます。",
+    controlCalloutTwo: "詳細を開く前にホスト行でコマンド取得状況を確認できます。",
+    annotateBatch: "一括取得",
+    annotateProgress: "タスク進捗",
+    annotateCoverage: "コマンド別取得状況",
     detailTitle: "コマンド単位で確認するホスト詳細",
     detailText:
       "ホスト画面では、インベントリ情報、取得操作、比較サマリ、コマンド出力を1台分の証跡としてまとめて確認できます。",
+    detailCalloutOne: "出力確認中もインベントリ情報を見失いません。",
+    detailCalloutTwo: "変更あり/変更なしのコマンドを一続きで確認できます。",
+    annotateMetadata: "機器メタデータ",
+    annotateCompare: "比較操作",
+    annotateResults: "コマンド結果",
     logsTitle: "調査と引き継ぎのためのログ",
     logsText:
       "ランタイムログがワークフローの近くにあるため、失敗した取得やデプロイ確認を文脈付きで調査できます。",
+    logsCalloutOne: "フィルタでランタイム出力を扱いやすく保てます。",
+    logsCalloutTwo: "ログ行が失敗時の引き継ぎを支えます。",
+    annotateFilters: "ソース絞り込み",
+    annotateRuntime: "実行ログ",
     operateEyebrow: "ローカル起動",
     operateTitle: "v2 UIを起動し、自分の機器で同じツアーをたどる。",
     operateText: "起動後に http://127.0.0.1:5000/v2 を開きます。",
@@ -106,10 +146,14 @@ const setLanguage = (lang) => {
     button.setAttribute("aria-pressed", String(isActive));
   });
   localStorage.setItem("nwDiffTourLang", lang);
+  const url = new URL(window.location.href);
+  url.searchParams.set("lang", lang);
+  window.history.replaceState({}, "", url);
 };
 
 document.querySelectorAll(".lang-button").forEach((button) => {
   button.addEventListener("click", () => setLanguage(button.dataset.lang));
 });
 
-setLanguage(localStorage.getItem("nwDiffTourLang") || "en");
+const requestedLanguage = new URLSearchParams(window.location.search).get("lang");
+setLanguage(requestedLanguage || localStorage.getItem("nwDiffTourLang") || "en");


### PR DESCRIPTION
## Summary
- Add Open Graph/Twitter metadata for better link previews.
- Add a three-point value summary to the hero area.
- Add callouts and lightweight HTML annotations over the screenshots.
- Support `?lang=en` and `?lang=ja` URLs while preserving the language toggle.
- Add the tour link to `README_ja.md`.

## Validation
- Served `docs/` locally with `python3 -m http.server 8000 --directory docs`.
- Verified `/tour/?lang=en` loads with 3 value items and 8 annotations.
- Verified screenshots load successfully.
- Verified `/tour/?lang=ja` renders Japanese copy from the URL parameter.
- Verified mobile width has no horizontal overflow and annotations collapse inline.

## LLM involvement
Files modified with LLM assistance:
- `README_ja.md`
- `docs/tour/index.html`
- `docs/tour/tour.css`
- `docs/tour/tour.js`

Human review required for correctness, security, licensing, and final publishing behavior.